### PR TITLE
Enable ANSI output on Windows automatically

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -37,8 +37,6 @@ public abstract class AnsiOutput {
 
 	private static Boolean ansiCapable;
 
-	private static final String OPERATING_SYSTEM_NAME = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-
 	private static final String ENCODE_START = "\033[";
 
 	private static final String ENCODE_END = "m";
@@ -155,7 +153,7 @@ public abstract class AnsiOutput {
 			if ((consoleAvailable == null) && (System.console() == null)) {
 				return false;
 			}
-			return !(OPERATING_SYSTEM_NAME.contains("win"));
+			return true;
 		}
 		catch (Throwable ex) {
 			return false;


### PR DESCRIPTION
Windows supports ANSI encoding since Windows 10 version 1909. All you need to do is call ENABLE_VIRTUAL_TERMINAL_PROCESSING when calling console API.

IntelliJ does this automatically.
![image](https://user-images.githubusercontent.com/2323565/229367769-c6e6e489-a515-4144-93ed-250849356f5d.png)
All software running via the new Windows Terminal, including java, does this as well.
![image](https://user-images.githubusercontent.com/2323565/229367809-295d3814-8bdf-4b86-baa5-62c48779ad22.png)

Old Windows command prompt doesn't do this by default for compatibility reasons, but new Java versions will make it possible for workaround even for older Windows versions https://stackoverflow.com/questions/74319252/printing-ansi-color-codes-in-java-works-on-vs-code-terminal-but-not-in-cmd

My proposal is to enable ANSI coloring on Windows by default.